### PR TITLE
Allow checksums to have leading spaces

### DIFF
--- a/src/Data/Conduit/Tar.hs
+++ b/src/Data/Conduit/Tar.hs
@@ -114,7 +114,7 @@ parseHeader :: Offset -> ByteString -> Either TarException Header
 parseHeader offset bs = assert (S.length bs == 512) $ do
     let checksumBytes = S.take 8 $ S.drop 148 bs
         expectedChecksum = parseOctal checksumBytes
-        actualChecksum = bsum bs - bsum checksumBytes + 8 * 0x20
+        actualChecksum = bsum bs - bsum checksumBytes + 8 * space
     unless (actualChecksum == expectedChecksum) (Left (BadChecksum offset))
     return Header
         { headerOffset         = offset
@@ -143,7 +143,10 @@ parseHeader offset bs = assert (S.length bs == 512) $ do
     parseOctal :: Integral i => ByteString -> i
     parseOctal = S.foldl' (\t c -> t * 8 + fromIntegral (c - zero)) 0
                . S.takeWhile (\c -> zero <= c && c <= seven)
+               . S.dropWhile (== space)
 
+    space :: Integral i => i
+    space = 0x20
     zero = 48
     seven = 55
 


### PR DESCRIPTION
It seems to me that leading spaces are a non-standard feature, but one that is seen in the wild.  In particular the tar library already handles this case: <https://github.com/haskell/tar/commit/455a26e3b3771c560555ad915a4e3d9b1c4d9a13>.

I've hit this bug while trying to parse a tarball that looked fine otherwise.  With this patch, it seems to work great!