### PR TITLE
Added support for hard links

### DIFF
--- a/src/Data/Conduit/Tar/Types.hs
+++ b/src/Data/Conduit/Tar/Types.hs
@@ -69,7 +69,7 @@ type GroupID = CGid
 
 data FileType
     = FTNormal
-    | FTHardLink
+    | FTHardLink !ByteString
     | FTSymbolicLink !ByteString
     | FTCharacterSpecial
     | FTBlockSpecial

--- a/src/Data/Conduit/Tar/Windows.hs
+++ b/src/Data/Conduit/Tar/Windows.hs
@@ -60,7 +60,7 @@ restoreFileInternal lenient fi@FileInfo {..} = do
     case fileType of
         FTDirectory -> do
             excs <- liftIO $ do
-                Dir.createDirectoryIfMissing False fpStr
+                Dir.createDirectoryIfMissing True fpStr
                 restoreTimeAndMode
             yield $ do
                 eExc <- tryAnyCond (Dir.doesDirectoryExist fpStr >>=

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -130,6 +130,7 @@ instance Arbitrary GnuTarFile where
                 [ pure FTNormal
                 , pure FTDirectory
                 , FTSymbolicLink <$> asciiGen linkNameLen
+                , FTHardLink <$> asciiGen linkNameLen
                 ]
         (fileSize, mContent) <-
             case fileType of


### PR DESCRIPTION
This patch adds support for hard links by enabling FTHardLink to hold a "linkname" (path of a linked file).
The patch also implements hard link handler logic for Unix (Windows only support hard links in special operation modes.).
`restoreFileInto` was also modified to prepend the supplied target directory to all the hard links (note that a hard link cannot be relative).