### PR TITLE
Lenient untaring with error reporting.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
-## 0.2.4 - 2018-07-25
+## 0.2.4 - 2018-08-28
+ * Use forward slashes on Windows too, see [issue #21](https://github.com/snoyberg/tar-conduit/issues/21)
  * Addition of `extractTarballLenient`
 
 ## 0.2.3.1 - 2018-06-06

--- a/src/Data/Conduit/Tar.hs
+++ b/src/Data/Conduit/Tar.hs
@@ -845,8 +845,10 @@ writeTarball tarHandle dirs = do
     runConduitRes $ yieldMany dirs .| void tarFilePath .| sinkHandle tarHandle
 
 
+-- always use forward slash, see
+-- https://github.com/snoyberg/tar-conduit/issues/21
 pathSeparatorS :: ByteString
-pathSeparatorS = S8.singleton pathSeparator
+pathSeparatorS = "/" -- S8.singleton pathSeparator
 
 
 fileInfoFromHeader :: Header -> FileInfo

--- a/src/Data/Conduit/Tar/Types.hs
+++ b/src/Data/Conduit/Tar/Types.hs
@@ -136,6 +136,7 @@ data TarException
     | InvalidHeader     !FileOffset
     | BadChecksum       !FileOffset
     | FileTypeError     !FileOffset !Char !String
+    | UnsupportedType   !FileType
     deriving (Show, Typeable)
 instance Exception TarException
 

--- a/src/Data/Conduit/Tar/Windows.hs
+++ b/src/Data/Conduit/Tar/Windows.hs
@@ -54,8 +54,8 @@ restoreFileInternal lenient fi@FileInfo {..} = do
         CTime modTimeEpoch = fileModTime
         modTime = posixSecondsToUTCTime (fromIntegral modTimeEpoch)
         restoreTimeAndMode = do
-            eExc2 <- tryAnyCond $ Dir.setModificationTime fpStr modTime
             eExc1 <- tryAnyCond $ Posix.setFileMode fpStr fileMode
+            eExc2 <- tryAnyCond $ Dir.setModificationTime fpStr modTime
             return $! fst $ partitionEithers [eExc1, eExc2]
     case fileType of
         FTDirectory -> do

--- a/tar-conduit.cabal
+++ b/tar-conduit.cabal
@@ -21,21 +21,20 @@ library
                      , bytestring
                      , conduit
                      , conduit-combinators >= 1.0.8.1
+                     , directory
                      , filepath
+                     , safe-exceptions
                      , text
   default-language:    Haskell2010
   ghc-options:         -Wall
   if os(windows)
       other-modules: Data.Conduit.Tar.Windows
-      build-depends: directory
-                   , time
+      build-depends: time
                    , unix-compat
       cpp-options:   -DWINDOWS
   else
       other-modules: Data.Conduit.Tar.Unix
-      build-depends: directory
-                   , safe-exceptions
-                   , unix
+      build-depends: unix
 
 test-suite tests
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
Major contribution is proper implementation of `extractTarballLenient`. Restoring of files and folders is now done in such a way that on demand either an error gets thrown or all errors on individual tar objects get collected and reported back to the user as a list of exceptions. 